### PR TITLE
[Feat/11] 컬렉션 조회 API 구현

### DIFF
--- a/src/main/java/com/example/gojipserver/domain/collection/controller/CollectionController.java
+++ b/src/main/java/com/example/gojipserver/domain/collection/controller/CollectionController.java
@@ -1,5 +1,6 @@
 package com.example.gojipserver.domain.collection.controller;
 
+import com.example.gojipserver.domain.collection.dto.CollectionResponseDto;
 import com.example.gojipserver.domain.collection.dto.CollectionSaveDto;
 import com.example.gojipserver.domain.collection.service.CollectionService;
 import com.example.gojipserver.domain.oauth2.entity.UserPrincipal;
@@ -12,6 +13,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
+
 @Tag(name = "Collection API", description = "테스트 API")
 @RequiredArgsConstructor
 @RestController
@@ -22,23 +25,32 @@ public class CollectionController {
 
     // TODO: collectionName null, 중복 예외 처리
     @PostMapping
-    @Operation(summary = "컬렉션 등록", description = "로그인한 유저의 정보를 받아 컬렉션을 등록")
-    @Parameter(name = "collectionSaveDto", description = "collectionName을 받습니다.")
-    public ApiResponse<Long> saveCollection(@AuthenticationPrincipal UserPrincipal userPrincipal, @RequestBody @Valid CollectionSaveDto collectionSaveDto) {
+    @Operation(summary = "컬렉션 등록", description = "요청한 유저의 정보를 받아 컬렉션을 등록")
+    @Parameter(name = "collectionSaveDto", description = "collectionName을 담은 DTO")
+    public ApiResponse<Long> saveCollection(@AuthenticationPrincipal UserPrincipal requestUser, @RequestBody @Valid CollectionSaveDto collectionSaveDto) {
 
-        Long savedCollectionId = collectionService.saveCollection(userPrincipal.getId(), collectionSaveDto);
+        Long savedCollectionId = collectionService.saveCollection(requestUser.getId(), collectionSaveDto);
         return ApiResponse.createSuccess(savedCollectionId);
     }
 
-
     @DeleteMapping("/{id}")
-    @Operation(summary = "컬렉션 삭제", description = "컬렉션을 삭제, 삭제 요청을 한 유저가 해당 컬렉션의 주인인지 확인")
+    @Operation(summary = "컬렉션 단일 삭제", description = "컬렉션을 삭제, 삭제 요청을 한 유저가 해당 컬렉션의 주인인지 확인")
     @Parameter(name = "id", description = "삭제할 Collection의 id")
-    public ApiResponse<?> deleteCollection(@AuthenticationPrincipal UserPrincipal userPrincipal, @PathVariable Long id) {
+    public ApiResponse<?> deleteCollection(@AuthenticationPrincipal UserPrincipal requestUser, @PathVariable Long id) {
 
-        collectionService.deleteCollection(userPrincipal.getId(), id);
+        collectionService.deleteCollection(requestUser.getId(), id);
 
         return ApiResponse.createSuccessWithNoContent();
+    }
+
+    @GetMapping
+    @Operation(summary = "유저의 컬렉션 조회", description = "요청한 유저의 정보를 받아 컬렉션을 조회")
+    @Parameter(name = "collectionSaveDto", description = "collectionName을 받습니다.")
+    public ApiResponse<List<CollectionResponseDto>> getCollections(@AuthenticationPrincipal UserPrincipal requestUser) {
+
+        List<CollectionResponseDto> collectionList = collectionService.getCollections(requestUser.getId());
+
+        return ApiResponse.createSuccess(collectionList);
     }
 
 }

--- a/src/main/java/com/example/gojipserver/domain/collection/dto/CollectionResponseDto.java
+++ b/src/main/java/com/example/gojipserver/domain/collection/dto/CollectionResponseDto.java
@@ -1,0 +1,22 @@
+package com.example.gojipserver.domain.collection.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class CollectionResponseDto {
+
+    private Long id;
+
+    private String collectionName;
+
+    @Builder
+    public CollectionResponseDto(Long id, String collectionName) {
+        this.id = id;
+        this.collectionName = collectionName;
+    }
+
+
+}

--- a/src/main/java/com/example/gojipserver/domain/collection/repository/CollectionRepository.java
+++ b/src/main/java/com/example/gojipserver/domain/collection/repository/CollectionRepository.java
@@ -1,7 +1,17 @@
 package com.example.gojipserver.domain.collection.repository;
 
+import com.example.gojipserver.domain.collection.dto.CollectionResponseDto;
 import com.example.gojipserver.domain.collection.entity.Collection;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.List;
 
 public interface CollectionRepository extends JpaRepository<Collection, Long> {
+
+    @Query("select new com.example.gojipserver.domain.collection.dto.CollectionResponseDto(c.id, c.collectionName) " +
+            "from Collection c where c.user.id = :userId " +
+            "order by c.id asc")
+    List<CollectionResponseDto> findCollectionsByUserId(Long userId);
+
 }

--- a/src/main/java/com/example/gojipserver/domain/collection/service/CollectionService.java
+++ b/src/main/java/com/example/gojipserver/domain/collection/service/CollectionService.java
@@ -1,5 +1,6 @@
 package com.example.gojipserver.domain.collection.service;
 
+import com.example.gojipserver.domain.collection.dto.CollectionResponseDto;
 import com.example.gojipserver.domain.collection.dto.CollectionSaveDto;
 import com.example.gojipserver.domain.collection.entity.Collection;
 import com.example.gojipserver.domain.collection.repository.CollectionRepository;
@@ -10,6 +11,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
 
 
 @Service
@@ -42,4 +44,10 @@ public class CollectionService {
 
         collectionRepository.delete(findCollection);
     }
+
+    // TODO:
+    public List<CollectionResponseDto> getCollections(Long requestUserId) {
+        return collectionRepository.findCollectionsByUserId(requestUserId);
+    }
+
 }

--- a/src/main/java/com/example/gojipserver/domain/user/entity/User.java
+++ b/src/main/java/com/example/gojipserver/domain/user/entity/User.java
@@ -17,6 +17,7 @@ import java.util.List;
 public class User {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "users_id")
     private Long id;
 
     @OneToMany(mappedBy = "user")

--- a/src/main/java/com/example/gojipserver/global/config/SecurityConfig.java
+++ b/src/main/java/com/example/gojipserver/global/config/SecurityConfig.java
@@ -18,6 +18,11 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 @EnableWebSecurity
 @RequiredArgsConstructor
 public class SecurityConfig {
+    private static final String[] AUTH_WHITELIST = {
+            "/oauth2/**", "/login", "/swagger-ui/**", "/api-docs", "/swagger-ui-custom.html",
+            "/v3/api-docs/**", "/api-docs/**", "/swagger-ui.html"
+    }; // 인증 필터를 거치지 않는 경로
+
     private final CustomOAuth2UserService customOAuth2Service;
     private final CustomUserDetailsService customUserDetailsService;
     private final OAuth2AuthenticationSuccessHandler oAuth2AuthenticationSuccessHandler;
@@ -34,10 +39,8 @@ public class SecurityConfig {
         );
 
         http.authorizeRequests(authorizeRequests -> authorizeRequests
-                .requestMatchers("/oauth2/**").permitAll() // oauth2로 시작하는 모든 요청은 인증 없이 접근 가능
-                .requestMatchers("/login").permitAll() // login으로 시작하는 모든 요청은 인증 없이 접근 가능
-                .requestMatchers("/swagger-ui/index.html").permitAll()
-//                .anyRequest().authenticated() // 나머지 요청은 모두 인증 필요
+                .requestMatchers(AUTH_WHITELIST).permitAll()
+                .anyRequest().authenticated() // 나머지 요청은 모두 인증 필요
         );
 
         http.oauth2Login(oauth->oauth

--- a/src/main/java/com/example/gojipserver/global/response/ApiResponse.java
+++ b/src/main/java/com/example/gojipserver/global/response/ApiResponse.java
@@ -2,6 +2,7 @@ package com.example.gojipserver.global.response;
 
 
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -28,6 +29,7 @@ public class ApiResponse<T> {
         return new ApiResponse<>(false, StatusEnum.BAD_REQUEST, null, message);
     }
 
+    @Builder
     private ApiResponse(boolean isSuccess, StatusEnum status, T data, String message) {
         this.isSuccess = isSuccess;
         this.status = status;

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -7,6 +7,7 @@ spring:
       - classpath:application-credentials.yml
       - classpath:application-oauth.yml
       - classpath:application-jwt.yml
+      - classpath:application-swagger.yml
 
 
   datasource:

--- a/src/main/resources/application-swagger.yml
+++ b/src/main/resources/application-swagger.yml
@@ -1,0 +1,18 @@
+springdoc:
+  packages-to-scan: com.example.gojipserver.domain
+  paths-to-match: /**
+  default-consumes-media-type: application/json;charset=UTF-8
+  default-produces-media-type: application/json;charset=UTF-8
+
+  swagger-ui:
+    path: api-docs
+    tags-sorter: alpha
+    operations-sorter: alpha
+
+  api-docs:
+    path: /api-docs/json
+    groups:
+      enabled: true
+
+  cache:
+    disabled: true


### PR DESCRIPTION
<!-- 제목양식을 지켜주세요! [Feat/#{이슈번호}] {제목~~} -->
<!--
[점검사항]
1. 제목 양식
2. Development 이슈 링크 걸기
3. Labels 태그 설정하기
4. 방금 작성한 코드가 최선일까 고민해보기
-->
### Issue Link
<!-- #{본인 이슈 번호} 치면 알아서 이슈 게시판 링크 걸려요 -->
- #15 

### 핵심 내용
<!-- 무엇을 했는가 -->
- 회원의 컬렉션 조회 API 구현
- swagger에 컨트롤러 등록 이슈 해결
- User, 공통 응답 클래스 리팩토링

### 핵심 구현 방법
<!-- 어떻게 했는가 -->
- 사용자 정의 쿼리 작성 (`@Query`)
- application-swagger.yml 파일 설정
- User 클래스의 id 필드에 `@Column`의 name 옵션 적용
- ApiResponse의 생성자에 `@Builder` 추가

